### PR TITLE
Add link to temporary legate.core repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,10 @@ In general, a Legate application will need to implement three pieces.
 1. C++ tasks
 1. Python library
 
-Please refer to the README in the [Legate repo](https://github.com/nv-legate/legate.core/blob/branch-23.03/README.md)
-for first installing `legate.core`.  We strongly recommend creating a Conda environment for development and testing.
+Please refer to the BUILD.md in [this repository and branch](https://github.com/jjwilke/legate.core/tree/hello-world-boilerplate)
+for first installing `legate.core`.  You will need to setup legate.core from this
+repository until the work is merged into the main repository. We strongly recommend
+creating a Conda environment for development and testing.
 
 # Build System
 
@@ -19,7 +21,7 @@ for first installing `legate.core`.  We strongly recommend creating a Conda envi
 To build the project, the user can do the following:
 
 ```
-$ cmake -S . -B build -D legate_core_ROOT=<legate_install>
+$ cmake -S . -B build
 $ cmake --build build
 $ python -m pip install -e .
 ```


### PR DESCRIPTION
This is a tweak to the `README` to link to the fork and branch of legate.core that is needed to run this example repository.

I think it is useful to link directly to that so that people who discover this repository can get started without having to ask someone why following the instructions doesn't work. Once that branch has been merged we can go back to the shorter instructions.

I also removed the `-D legate_core_ROOT=<legate_install>` argument from the `cmake` command as it seems to work without it (auto discovered) and it was not clear to me how to find out what the right value for this would be. An alternative would be to add a short sentence explaining how to find out what the value of `<legate_install>`  should be.

What do you think?